### PR TITLE
Documentation updates

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Change history for Term-Spinner-Lite
 
 {{$NEXT}}
             Set pod encoding to UTF-8
+            Added a SEE ALSO section to doc
 
 0.03        2013-01-03
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for Term-Spinner-Lite
 
 {{$NEXT}}
+            Set pod encoding to UTF-8
 
 0.03        2013-01-03
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ version 0.03
 
 This is a simple spinner, useful when you want to show some kind of activity 
 during a long-running activity of non-determinant length.  It's loosely based
-on the API from [Term::Spinner](http://search.cpan.org/perldoc?Term::Spinner).  Unlike [Term::Spinner](http://search.cpan.org/perldoc?Term::Spinner) though, this module
+on the API from [Term::Spinner](https://metacpan.org/pod/Term::Spinner).  Unlike [Term::Spinner](https://metacpan.org/pod/Term::Spinner) though, this module
 doesn't have any dependencies outside of modules shipped with Perl itself.
 
 # ATTRIBUTES
@@ -66,6 +66,20 @@ it to `output_handle`.
 
 Finish spinning, and clear the last character printed. If a true value is passed,
 output a newline.
+
+# SEE ALSO
+
+[Term::Spinner](https://metacpan.org/pod/Term::Spinner) is similar to this module, but depends on Moose,
+and only had one release, in 2007.
+
+[Term::Spinner::Color](https://metacpan.org/pod/Term::Spinner::Color) is similar to this module,
+but only has core dependencies, and offers colour as well.
+
+There are many modules for displaying a progress bar rather than a spinner.
+[Term::ProgressBar](https://metacpan.org/pod/Term::ProgressBar) is well documented.
+[Term::ProgressSpinner](https://metacpan.org/pod/Term::ProgressSpinner) displays a progress bar, using one of a range
+of Unicode characters to render the bar.
+Search for "progress" on MetaCPAN to see many more.
 
 # AUTHOR
 

--- a/lib/Term/Spinner/Lite.pm
+++ b/lib/Term/Spinner/Lite.pm
@@ -211,3 +211,18 @@ sub done {
 }
 
 1;
+
+=head1 SEE ALSO
+
+L<Term::Spinner> is similar to this module, but depends on Moose,
+and only had one release, in 2007.
+
+L<Term::Spinner::Color> is similar to this module,
+but only has core dependencies, and offers colour as well.
+
+There are many modules for displaying a progress bar rather than a spinner.
+L<Term::ProgressBar> is well documented.
+L<Term::ProgressSpinner> displays a progress bar, using one of a range
+of Unicode characters to render the bar.
+Search for "progress" on MetaCPAN to see many more.
+

--- a/lib/Term/Spinner/Lite.pm
+++ b/lib/Term/Spinner/Lite.pm
@@ -9,6 +9,8 @@ use IO::Handle;
 use Time::HiRes qw(usleep);
 use Carp qw( croak );
 
+=encoding UTF-8
+
 =head1 SYNOPSIS
 
   use utf8;


### PR DESCRIPTION
Hi Mark,

When you look at the documentation for this module on MetaCPAN, it says there's a pod error.
This was fixed by setting the pod encoding to utf8.

I also added a SEE ALSO section, which mentions the other spinners on CPAN,
and a couple of the progress bar modules.

Cheers,
Neil
